### PR TITLE
DEV-14278 Suppress AWS002 warning.

### DIFF
--- a/modules/encrypted-bucket/main.tf
+++ b/modules/encrypted-bucket/main.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket" "new_bucket" {
+resource "aws_s3_bucket" "new_bucket" { #tfsec:ignore:AWS002
   bucket = var.bucket_name
   acl    = "private"
 


### PR DESCRIPTION
[DEV-14278](https://datatamr.atlassian.net/browse/DEV-14278) - Suppressed the "enable server access logging on buckets" warning. @souza-dan Should I create a card in the backlog for this? Wasn't sure if this was something we actually wanted to look into enabling.

[DEV-14279](https://datatamr.atlassian.net/browse/DEV-14279) - No changes to the examples seemed necessary.